### PR TITLE
is_connected() now pings database once, not twice

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for DBD-Safe
 
 {{$NEXT}}
+        - is_connected() now pings database once, not twice
+
+0.04    2010-11-30
         - remove unneeded (now) eval
         - add last_insert_id prototype
 

--- a/lib/DBD/Safe.pm
+++ b/lib/DBD/Safe.pm
@@ -443,7 +443,7 @@ sub is_connected {
     my $active = $state->{dbh}->{Active} || '';
     my $ping = $state->{dbh}->ping || '';
 
-    return $state->{dbh}->{Active} && $state->{dbh}->ping;
+    return $active && $ping;
 }
 
 sub real_connect {


### PR DESCRIPTION
For some reason is_connected() function did its checks twice.
This trivial patch should fix this.
