### PR TITLE
Skip DBD::File::dr as a dependency as it is included in DBD::File

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -9,6 +9,8 @@ bundle = @Classic
 remove = PodCoverageTests
 
 [AutoPrereqs]
+skip = ^DBD::File::dr$
+
 [NextRelease]
 format = %-7v %{yyyy-MM-dd}d
 


### PR DESCRIPTION
I'm not sure if something changed in DBD::File but this was causing DBD::Safe to not install even though I had
all required dependencies.
